### PR TITLE
docs: Added Swagger UI documentation using SpringDoc OpenAPI

### DIFF
--- a/fulfillment-centers/pom.xml
+++ b/fulfillment-centers/pom.xml
@@ -76,7 +76,22 @@
             <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- SpringDoc OpenAPI and Swagger -->
+        <!-- For the integration between spring-boot and swagger-ui -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
     </dependencies>
+
+
 
     <build>
         <plugins>

--- a/fulfillment-centers/src/main/java/com/gulbalasalamov/fulfillment_centers/FulfillmentCentersApplication.java
+++ b/fulfillment-centers/src/main/java/com/gulbalasalamov/fulfillment_centers/FulfillmentCentersApplication.java
@@ -1,7 +1,12 @@
 package com.gulbalasalamov.fulfillment_centers;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@EnableWebMvc
+@OpenAPIDefinition
 
 @SpringBootApplication
 public class FulfillmentCentersApplication {

--- a/fulfillment-centers/src/main/java/com/gulbalasalamov/fulfillment_centers/config/SwaggerConfig.java
+++ b/fulfillment-centers/src/main/java/com/gulbalasalamov/fulfillment_centers/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.gulbalasalamov.fulfillment_centers.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI springShopOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Fulfillment Centers API")
+                        .description("API Endpoint Decoration")
+                        .version("v1.0")
+                        .contact(newContact())
+                        .license(new License().name("Apache 2.0").url("http://springdoc.org")))
+                .externalDocs(new ExternalDocumentation()
+                        .description("API Documentation")
+                        .url("github.com/gulbalasalamov/fulfillment-centers"));
+    }
+
+    private Contact newContact(){
+        Contact contact = new Contact();
+        contact.setName("Gulbala Salamov");
+        contact.setUrl("https://www.github.com/gulbalasalamov");
+        contact.setEmail("g.salamov@gmail.com");
+        return contact;
+    }
+}
+

--- a/fulfillment-centers/src/main/resources/application.properties
+++ b/fulfillment-centers/src/main/resources/application.properties
@@ -7,3 +7,10 @@ spring.datasource.password=postgres
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+
+
+# springdoc.api-docs.path=/api-docs
+ springdoc.swagger-ui.path=/swagger-ui/index.html
+
+


### PR DESCRIPTION
- Integrated SpringDoc OpenAPI for API documentation
- Configured Swagger UI endpoint at /swagger-ui/index.html
- Added Swagger configuration class for API info and contact details
- Removed conflicting SpringFox dependencies to resolve application startup issues

This commit enhances the project by adding a comprehensive API documentation tool, making it easier for developers to understand and interact with the API.